### PR TITLE
Improved creation & edition security

### DIFF
--- a/services/web/karikariyaki/package-lock.json
+++ b/services/web/karikariyaki/package-lock.json
@@ -1251,9 +1251,9 @@
             }
         },
         "node_modules/karikarihelper": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/karikarihelper/-/karikarihelper-1.7.0.tgz",
-            "integrity": "sha512-yHm3QXlui0U9vyy70NQhHEoCd0HXVwDUWVeOgnqhg29ee83qVr+2gqPuWKMCKlXPVXaT9Dbuc6WsHVkL5oCxhQ=="
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/karikarihelper/-/karikarihelper-1.7.2.tgz",
+            "integrity": "sha512-JEy8tpVNYQBejGk5frXrl9zwUcx1uNpbUzlTGXWmkNJhuNHthg7Ua5dnqIQknPs0BQJB4Id803+0FEKwDtLT5w=="
         },
         "node_modules/locate-path": {
             "version": "5.0.0",
@@ -3663,9 +3663,9 @@
             "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA=="
         },
         "karikarihelper": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/karikarihelper/-/karikarihelper-1.7.0.tgz",
-            "integrity": "sha512-yHm3QXlui0U9vyy70NQhHEoCd0HXVwDUWVeOgnqhg29ee83qVr+2gqPuWKMCKlXPVXaT9Dbuc6WsHVkL5oCxhQ=="
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/karikarihelper/-/karikarihelper-1.7.2.tgz",
+            "integrity": "sha512-JEy8tpVNYQBejGk5frXrl9zwUcx1uNpbUzlTGXWmkNJhuNHthg7Ua5dnqIQknPs0BQJB4Id803+0FEKwDtLT5w=="
         },
         "locate-path": {
             "version": "5.0.0",

--- a/services/web/karikariyaki/src/routes/api/v1/admin/registry/event/event.ts
+++ b/services/web/karikariyaki/src/routes/api/v1/admin/registry/event/event.ts
@@ -3,118 +3,104 @@ import { Router } from "express";
 // Services
 import { EventService, RequestService, ResponseService } from "@services";
 
-// Models
+// Types
 import { EventErrors } from "@models";
+import { InHouseError } from "@types";
 
 const router = Router();
 
-router.get("/", (req, res) => {
-    EventService.query({
-        id: RequestService.queryParamToString(req.query.id),
-        name: RequestService.queryParamToString(req.query.name),
-        date: RequestService.queryParamToDate(req.query.date),
-        isOpen: RequestService.queryParamToBoolean(req.query.isOpen),
-    })
-        .then((response) => {
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
+router.get("/", async (req, res) => {
+    try {
+        const foundEvents = await EventService.query({
+            id: RequestService.queryParamToString(req.query.id),
+            name: RequestService.queryParamToString(req.query.name),
+            date: RequestService.queryParamToDate(req.query.date),
+            isOpen: RequestService.queryParamToBoolean(req.query.isOpen),
         });
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(foundEvents)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
 });
 
-router.post("/", (req, res) => {
-    const name = req.body.name;
-    const date = RequestService.queryParamToDate(req.body.date);
-    const isOpen = RequestService.queryParamToBoolean(req.body.isOpen);
+router.post("/", async (req, res) => {
+    try {
+        const name = req.body.name;
+        const date = RequestService.queryParamToDate(req.body.date);
+        const isOpen = RequestService.queryParamToBoolean(req.body.isOpen);
 
-    if (!name || !date) {
-        res.status(400).json(
-            ResponseService.generateFailedResponse(EventErrors.INVALID)
-        );
+        if (!name || !date) {
+            throw new InHouseError(EventErrors.INVALID, 400);
+        }
 
-        return;
-    }
-
-    EventService.save({
-        name: name,
-        date: date,
-        isOpen: isOpen,
-    })
-        .then((response) => {
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
+        const response = await EventService.save({
+            name: name,
+            date: date,
+            isOpen: isOpen,
         });
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
 });
 
-router.patch("/:id", (req, res) => {
-    const id = req.params.id;
-    const name = req.body.name;
-    const isOpen = RequestService.queryParamToBoolean(req.body.isOpen);
+router.patch("/:id", async (req, res) => {
+    try {
+        const id = req.params.id;
+        const name = req.body.name;
+        const isOpen = RequestService.queryParamToBoolean(req.body.isOpen);
 
-    if (!id) {
-        res.status(400).json(
-            ResponseService.generateFailedResponse(EventErrors.INVALID)
-        );
+        if (!id) {
+            throw new InHouseError(EventErrors.INVALID, 400);
+        }
 
-        return;
-    }
-
-    EventService.update(id, { name: name, isOpen: isOpen })
-        .then((response) => {
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
+        const response = await EventService.update(id, {
+            name: name,
+            isOpen: isOpen,
         });
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
 });
 
-router.delete("/:id", (req, res) => {
-    const id = req.params.id;
+router.delete("/:id", async (req, res) => {
+    try {
+        const id = req.params.id;
 
-    if (!id) {
-        res.status(400).json(
-            ResponseService.generateFailedResponse(EventErrors.INVALID)
+        if (!id) {
+            throw new InHouseError(EventErrors.INVALID, 400);
+        }
+
+        const response = await EventService.delete(id);
+
+        if (!response) {
+            throw new InHouseError(EventErrors.NOT_FOUND, 404);
+        }
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
         );
-
-        return;
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
     }
-
-    EventService.delete(id)
-        .then((response) => {
-            if (!response) {
-                res.status(404).json(
-                    ResponseService.generateFailedResponse(
-                        EventErrors.NOT_FOUND
-                    )
-                );
-
-                return;
-            }
-
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
-        });
 });
 
 export default router;

--- a/services/web/karikariyaki/src/routes/api/v1/admin/registry/event/event.ts
+++ b/services/web/karikariyaki/src/routes/api/v1/admin/registry/event/event.ts
@@ -6,6 +6,7 @@ import { EventService, RequestService, ResponseService } from "@services";
 // Types
 import { EventErrors } from "@models";
 import { InHouseError } from "@types";
+import { Operator } from "karikarihelper";
 
 const router = Router();
 
@@ -38,11 +39,14 @@ router.post("/", async (req, res) => {
             throw new InHouseError(EventErrors.INVALID, 400);
         }
 
-        const response = await EventService.save({
-            name: name,
-            date: date,
-            isOpen: isOpen,
-        });
+        const response = await EventService.save(
+            res.locals.operator as Operator,
+            {
+                name: name,
+                date: date,
+                isOpen: isOpen,
+            }
+        );
 
         res.status(200).json(
             ResponseService.generateSucessfulResponse(response)
@@ -64,10 +68,14 @@ router.patch("/:id", async (req, res) => {
             throw new InHouseError(EventErrors.INVALID, 400);
         }
 
-        const response = await EventService.update(id, {
-            name: name,
-            isOpen: isOpen,
-        });
+        const response = await EventService.update(
+            res.locals.operator as Operator,
+            id,
+            {
+                name: name,
+                isOpen: isOpen,
+            }
+        );
 
         res.status(200).json(
             ResponseService.generateSucessfulResponse(response)
@@ -87,7 +95,10 @@ router.delete("/:id", async (req, res) => {
             throw new InHouseError(EventErrors.INVALID, 400);
         }
 
-        const response = await EventService.delete(id);
+        const response = await EventService.delete(
+            res.locals.operator as Operator,
+            id
+        );
 
         if (!response) {
             throw new InHouseError(EventErrors.NOT_FOUND, 404);

--- a/services/web/karikariyaki/src/routes/api/v1/admin/registry/event/order.ts
+++ b/services/web/karikariyaki/src/routes/api/v1/admin/registry/event/order.ts
@@ -10,6 +10,7 @@ import { OrderErrors } from "@models";
 
 // Enums
 import { OrderStatus } from "@enums";
+import { InHouseError } from "@types";
 
 const router = Router();
 
@@ -17,186 +18,187 @@ export enum RedirectorErrors {
     CLIENT_APP_ADDRESS_MISSING = "ERROR_CLIENT_APP_ADDRESS_MISSING",
 }
 
-router.get("/", (req, res) => {
-    OrderService.query(res.locals.operator as Operator, {
-        id: RequestService.queryParamToString(req.query.id),
-        eventId: RequestService.queryParamToString(req.query.eventId),
-        status: RequestService.queryParamToString(req.query.status),
-        operatorId: RequestService.queryParamToString(req.query.operatorId),
-        clientName: RequestService.queryParamToString(req.query.clientName),
-        itemsId: RequestService.queryParamToStrings(req.query.itemId),
-    })
-        .then((response) => {
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
-        });
+router.get("/", async (req, res) => {
+    try {
+        const foundEventOrders = await OrderService.query(
+            res.locals.operator as Operator,
+            {
+                id: RequestService.queryParamToString(req.query.id),
+                eventId: RequestService.queryParamToString(req.query.eventId),
+                status: RequestService.queryParamToString(req.query.status),
+                operatorId: RequestService.queryParamToString(
+                    req.query.operatorId
+                ),
+                clientName: RequestService.queryParamToString(
+                    req.query.clientName
+                ),
+                itemsId: RequestService.queryParamToStrings(req.query.itemId),
+            }
+        );
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(foundEventOrders)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
 });
 
 router.get("/status", (req, res) => {
-    res.status(200).json(
-        ResponseService.generateSucessfulResponse(Object.values(OrderStatus))
-    );
-});
-
-router.get("/qr/:orderId", (req, res) => {
-    if (!process.env["CLIENT_APP_ADDRESS"]) {
-        res.status(500).json(
-            ResponseService.generateFailedResponse(
-                RedirectorErrors.CLIENT_APP_ADDRESS_MISSING
+    try {
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(
+                Object.values(OrderStatus)
             )
         );
-
-        return;
-    }
-
-    const orderId = req.params.orderId;
-
-    if (!orderId) {
-        res.status(400).json(
-            ResponseService.generateFailedResponse(OrderErrors.INVALID)
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
         );
-
-        return;
     }
+});
 
-    OrderService.queryById(orderId)
-        .then((foundOrder) => {
-            if (!foundOrder) {
-                res.status(404).json(
-                    ResponseService.generateFailedResponse(
-                        OrderErrors.NOT_FOUND
-                    )
-                );
+router.get("/qr/:orderId", async (req, res) => {
+    try {
+        if (!process.env["CLIENT_APP_ADDRESS"]) {
+            throw new InHouseError(RedirectorErrors.CLIENT_APP_ADDRESS_MISSING);
+        }
 
-                return;
+        const orderId = req.params.orderId;
+
+        if (!orderId) {
+            throw new InHouseError(OrderErrors.INVALID, 400);
+        }
+
+        const foundOrder = await OrderService.queryById(orderId);
+
+        if (!foundOrder) {
+            throw new InHouseError(OrderErrors.NOT_FOUND, 404);
+        }
+
+        const redirectorURI = `${process.env["CLIENT_APP_ADDRESS"]}/order/${foundOrder.id}`;
+
+        const result = await QRCode.toDataURL(redirectorURI, {
+            color: {
+                light: "#0000",
+            },
+            width: 512,
+        });
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse({
+                base64: result,
+                redirector: redirectorURI,
+            } as QrCodeRseponse)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
+});
+
+router.post("/", async (req, res) => {
+    try {
+        const eventId = RequestService.queryParamToString(req.body.eventId);
+        const clientName = RequestService.queryParamToString(
+            req.body.clientName
+        );
+        const itemsId = RequestService.queryParamToStrings(req.body.itemsId);
+
+        // Non obligatory params
+        const operatorId = RequestService.queryParamToString(
+            req.body.operatorId
+        );
+        const status = RequestService.queryParamToString(req.body.status);
+
+        if (!eventId || !clientName || !itemsId || itemsId.length === 0) {
+            throw new InHouseError(OrderErrors.INVALID, 400);
+        }
+
+        const response = await OrderService.save(
+            res.locals.operator as Operator,
+            {
+                eventId: eventId,
+                status: status,
+                operatorId: operatorId,
+                clientName: clientName,
+                itemsId: itemsId,
             }
-
-            const redirectorURI = `${process.env["CLIENT_APP_ADDRESS"]}/order/${foundOrder.id}`;
-
-            QRCode.toDataURL(redirectorURI, {
-                color: {
-                    light: "#0000",
-                },
-                width: 512,
-            })
-                .then((result) => {
-                    res.status(200).json(
-                        ResponseService.generateSucessfulResponse({
-                            base64: result,
-                            redirector: redirectorURI,
-                        } as QrCodeRseponse)
-                    );
-                })
-                .catch((error) => {
-                    ResponseService.generateFailedResponse(error.message);
-                });
-        })
-        .catch((error) => {
-            ResponseService.generateFailedResponse(error.message);
-        });
-});
-
-router.post("/", (req, res) => {
-    const eventId = RequestService.queryParamToString(req.body.eventId);
-    const clientName = RequestService.queryParamToString(req.body.clientName);
-    const itemsId = RequestService.queryParamToStrings(req.body.itemsId);
-
-    // Non obligatory params
-    const operatorId = RequestService.queryParamToString(req.body.operatorId);
-    const status = RequestService.queryParamToString(req.body.status);
-
-    if (!eventId || !clientName || !itemsId || itemsId.length === 0) {
-        res.status(400).json(
-            ResponseService.generateFailedResponse(OrderErrors.INVALID)
         );
 
-        return;
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
     }
-
-    OrderService.save(res.locals.operator as Operator, {
-        eventId: eventId,
-        status: status,
-        operatorId: operatorId,
-        clientName: clientName,
-        itemsId: itemsId,
-    })
-        .then((response) => {
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
-        });
 });
 
-router.patch("/:id", (req, res) => {
-    const id = req.params.id;
-    const status = RequestService.queryParamToString(req.body.status);
+router.patch("/:id", async (req, res) => {
+    try {
+        const id = req.params.id;
+        const status = RequestService.queryParamToString(req.body.status);
 
-    if (!id) {
-        res.status(400).json(
-            ResponseService.generateFailedResponse(OrderErrors.INVALID)
-        );
+        if (!id) {
+            throw new InHouseError(OrderErrors.INVALID, 400);
+        }
 
-        return;
-    }
-
-    OrderService.update(res.locals.operator as Operator, id, {
-        status: status,
-    })
-        .then((response) => {
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
-        });
-});
-
-router.delete("/:id", (req, res) => {
-    const id = req.params.id;
-
-    if (!id) {
-        res.status(400).json(
-            ResponseService.generateFailedResponse(OrderErrors.INVALID)
-        );
-
-        return;
-    }
-
-    OrderService.delete(res.locals.operator as Operator, id)
-        .then((response) => {
-            if (!response) {
-                res.status(404).json(
-                    ResponseService.generateFailedResponse(
-                        OrderErrors.NOT_FOUND
-                    )
-                );
-
-                return;
+        const response = await OrderService.update(
+            res.locals.operator as Operator,
+            id,
+            {
+                status: status,
             }
+        );
 
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
+});
+
+router.delete("/:id", async (req, res) => {
+    try {
+        const id = req.params.id;
+
+        if (!id) {
+            res.status(400).json(
+                ResponseService.generateFailedResponse(OrderErrors.INVALID)
             );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
+
+            return;
+        }
+
+        const response = await OrderService.delete(
+            res.locals.operator as Operator,
+            id
+        );
+
+        if (!response) {
+            res.status(404).json(
+                ResponseService.generateFailedResponse(OrderErrors.NOT_FOUND)
             );
-        });
+
+            return;
+        }
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
 });
 
 export default router;

--- a/services/web/karikariyaki/src/routes/api/v1/admin/registry/menu.ts
+++ b/services/web/karikariyaki/src/routes/api/v1/admin/registry/menu.ts
@@ -1,173 +1,144 @@
 import { Router } from "express";
-import { Operator, OperatorRole } from "karikarihelper";
+import { Operator } from "karikarihelper";
+
+//Types
+import { MenuErrors } from "@models";
+import { InHouseError } from "@types";
 
 // Services
 import { MenuService, RequestService, ResponseService } from "@services";
 
-// Models
-import { MenuErrors, OperatorErrors } from "@models";
-
 const router = Router();
 
-router.get("/", (req, res) => {
-    const id = RequestService.queryParamToString(req.query.id);
-    const title = RequestService.queryParamToString(req.query.title);
-    const parentId = RequestService.queryParamToString(req.query.parentId);
+router.get("/", async (req, res) => {
+    try {
+        const id = RequestService.queryParamToString(req.query.id);
+        const title = RequestService.queryParamToString(req.query.title);
+        const parentId = RequestService.queryParamToString(req.query.parentId);
 
-    MenuService.query(res.locals.operator as Operator, {
-        id: id,
-        title: title,
-        parentId: parentId,
-    })
-        .then((response) => {
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
-        });
+        const response = await MenuService.query(
+            res.locals.operator as Operator,
+            {
+                id: id,
+                title: title,
+                parentId: parentId,
+            }
+        );
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
 });
 
-router.get("/self", (req, res) => {
-    MenuService.querySelf(res.locals.operator as Operator)
-        .then((response) => {
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
-        });
+router.get("/self", async (req, res) => {
+    try {
+        const response = await MenuService.querySelf(
+            res.locals.operator as Operator
+        );
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
 });
 
 router.post("/", (req, res) => {
-    const title = RequestService.queryParamToString(req.body.title);
-    const icon = RequestService.queryParamToString(req.body.icon);
-    const route = RequestService.queryParamToString(req.body.route);
-    const parentId = RequestService.queryParamToString(req.body.parentId);
+    try {
+        const title = RequestService.queryParamToString(req.body.title);
+        const icon = RequestService.queryParamToString(req.body.icon);
+        const route = RequestService.queryParamToString(req.body.route);
+        const parentId = RequestService.queryParamToString(req.body.parentId);
 
-    if (!title) {
-        res.status(400).json(
-            ResponseService.generateFailedResponse(MenuErrors.INVALID)
-        );
+        if (!title) {
+            throw new InHouseError(MenuErrors.INVALID, 400);
+        }
 
-        return;
-    }
-
-    const operator = res.locals.operator as Operator;
-
-    if (operator.role !== OperatorRole.ADMIN) {
-        res.status(403).json(
-            ResponseService.generateFailedResponse(OperatorErrors.FORBIDDEN)
-        );
-
-        return;
-    }
-
-    MenuService.save({
-        title: title,
-        icon: icon,
-        route: route,
-        parentId: parentId,
-    })
-        .then((response) => {
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
+        const response = MenuService.save(res.locals.operator as Operator, {
+            title: title,
+            icon: icon,
+            route: route,
+            parentId: parentId,
         });
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
 });
 
-router.patch("/:id", (req, res) => {
-    const id = req.params.id;
-    const icon = RequestService.queryParamToString(req.body.icon);
-    const title = RequestService.queryParamToString(req.body.title);
-    const route = RequestService.queryParamToString(req.body.route);
+router.patch("/:id", async (req, res) => {
+    try {
+        const id = req.params.id;
+        const icon = RequestService.queryParamToString(req.body.icon);
+        const title = RequestService.queryParamToString(req.body.title);
+        const route = RequestService.queryParamToString(req.body.route);
 
-    if (!id) {
-        res.status(400).json(
-            ResponseService.generateFailedResponse(MenuErrors.INVALID)
-        );
+        if (!id) {
+            throw new InHouseError(MenuErrors.INVALID, 400);
+        }
 
-        return;
-    }
-
-    const operator = res.locals.operator as Operator;
-
-    if (operator.role !== OperatorRole.ADMIN) {
-        res.status(403).json(
-            ResponseService.generateFailedResponse(OperatorErrors.FORBIDDEN)
-        );
-
-        return;
-    }
-
-    MenuService.update(id, {
-        icon: icon,
-        title: title,
-        route: route,
-    })
-        .then((response) => {
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
-        });
-});
-
-router.delete("/:id", (req, res) => {
-    const id = req.params.id;
-
-    if (!id) {
-        res.status(400).json(
-            ResponseService.generateFailedResponse(MenuErrors.INVALID)
-        );
-
-        return;
-    }
-
-    const operator = res.locals.operator as Operator;
-
-    if (operator.role !== OperatorRole.ADMIN) {
-        res.status(403).json(
-            ResponseService.generateFailedResponse(OperatorErrors.FORBIDDEN)
-        );
-
-        return;
-    }
-
-    MenuService.delete(id)
-        .then((response) => {
-            if (!response) {
-                res.status(404).json(
-                    ResponseService.generateFailedResponse(MenuErrors.NOT_FOUND)
-                );
-
-                return;
+        const response = await MenuService.update(
+            res.locals.operator as Operator,
+            id,
+            {
+                icon: icon,
+                title: title,
+                route: route,
             }
+        );
 
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
+});
+
+router.delete("/:id", async (req, res) => {
+    try {
+        const id = req.params.id;
+
+        if (!id) {
+            throw new InHouseError(MenuErrors.INVALID, 400);
+        }
+
+        const response = await MenuService.delete(
+            res.locals.operator as Operator,
+            id
+        );
+
+        if (!response) {
+            res.status(404).json(
+                ResponseService.generateFailedResponse(MenuErrors.NOT_FOUND)
             );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
-        });
+
+            return;
+        }
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
 });
 
 export default router;

--- a/services/web/karikariyaki/src/routes/api/v1/admin/registry/operator.ts
+++ b/services/web/karikariyaki/src/routes/api/v1/admin/registry/operator.ts
@@ -1,5 +1,9 @@
 import { Router } from "express";
-import { Operator, OperatorRole } from "karikarihelper";
+import { Operator } from "karikarihelper";
+
+// Types
+import { OperatorErrors } from "@models";
+import { InHouseError } from "@types";
 
 // Services
 import {
@@ -8,10 +12,6 @@ import {
     RequestService,
     ResponseService,
 } from "@services";
-
-// Models
-import { OperatorErrors } from "@models";
-import { InHouseError } from "@types";
 
 const router = Router();
 

--- a/services/web/karikariyaki/src/routes/api/v1/admin/registry/operator.ts
+++ b/services/web/karikariyaki/src/routes/api/v1/admin/registry/operator.ts
@@ -48,7 +48,7 @@ router.get("/roles", async (req, res) => {
 
         res.status(200).json(
             ResponseService.generateSucessfulResponse(
-                OperatorService.getValidRoles(operator.role)
+                OperatorService.getAvailableRolesByRole(operator.role)
             )
         );
     } catch (error) {

--- a/services/web/karikariyaki/src/routes/api/v1/admin/registry/product.ts
+++ b/services/web/karikariyaki/src/routes/api/v1/admin/registry/product.ts
@@ -3,115 +3,111 @@ import { Operator } from "karikarihelper";
 
 // Types
 import { ProductErrors } from "@models";
+import { InHouseError } from "@types";
 
 // Services
 import { RequestService, ResponseService, ProductService } from "@services";
 
 const router = Router();
 
-router.get("/", (req, res) => {
-    ProductService.query(res.locals.operator as Operator, {
-        id: RequestService.queryParamToString(req.query.id),
-        name: RequestService.queryParamToString(req.query.name),
-        realmId: RequestService.queryParamToString(req.query.realmId),
-    })
-        .then((response) => {
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
-        });
-});
-
-router.post("/", (req, res) => {
-    const name = RequestService.queryParamToString(req.body.name);
-    const realmId = RequestService.queryParamToString(req.body.realmId);
-
-    if (!name || !realmId) {
-        res.status(400).json(
-            ResponseService.generateFailedResponse(ProductErrors.INVALID)
-        );
-
-        return;
-    }
-
-    ProductService.save(res.locals.operator as Operator, {
-        name: name,
-        realmId: realmId,
-    })
-        .then((response) => {
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
-        });
-});
-
-router.patch("/:id", (req, res) => {
-    const id = req.params.id;
-    const name = RequestService.queryParamToString(req.body.name);
-
-    if (!id) {
-        res.status(400).json(
-            ResponseService.generateFailedResponse(ProductErrors.INVALID)
-        );
-
-        return;
-    }
-
-    ProductService.update(res.locals.operator as Operator, id, { name: name })
-        .then((response) => {
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
-        });
-});
-
-router.delete("/:id", (req, res) => {
-    const id = req.params.id;
-
-    if (!id) {
-        res.status(400).json(
-            ResponseService.generateFailedResponse(ProductErrors.INVALID)
-        );
-
-        return;
-    }
-
-    ProductService.delete(res.locals.operator as Operator, id)
-        .then((response) => {
-            if (!response) {
-                res.status(404).json(
-                    ResponseService.generateFailedResponse(
-                        ProductErrors.NOT_FOUND
-                    )
-                );
-
-                return;
+router.get("/", async (req, res) => {
+    try {
+        const foundProducts = await ProductService.query(
+            res.locals.operator as Operator,
+            {
+                id: RequestService.queryParamToString(req.query.id),
+                name: RequestService.queryParamToString(req.query.name),
+                realmId: RequestService.queryParamToString(req.query.realmId),
             }
+        );
 
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
-        });
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(foundProducts)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
+});
+
+router.post("/", async (req, res) => {
+    try {
+        const name = RequestService.queryParamToString(req.body.name);
+        const realmId = RequestService.queryParamToString(req.body.realmId);
+
+        if (!name) {
+            throw new InHouseError(ProductErrors.INVALID, 400);
+        }
+
+        const response = await ProductService.save(
+            res.locals.operator as Operator,
+            {
+                name: name,
+                realmId: realmId,
+            }
+        );
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
+});
+
+router.patch("/:id", async (req, res) => {
+    try {
+        const id = req.params.id;
+        const name = RequestService.queryParamToString(req.body.name);
+
+        if (!id) {
+            throw new InHouseError(ProductErrors.INVALID, 400);
+        }
+
+        const response = await ProductService.update(
+            res.locals.operator as Operator,
+            id,
+            { name: name }
+        );
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
+});
+
+router.delete("/:id", async (req, res) => {
+    try {
+        const id = req.params.id;
+
+        if (!id) {
+            throw new InHouseError(ProductErrors.INVALID, 400);
+        }
+
+        const response = await ProductService.delete(
+            res.locals.operator as Operator,
+            id
+        );
+
+        if (!response) {
+            throw new InHouseError(ProductErrors.NOT_FOUND, 404);
+        }
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
 });
 
 export default router;

--- a/services/web/karikariyaki/src/routes/api/v1/admin/registry/realm.ts
+++ b/services/web/karikariyaki/src/routes/api/v1/admin/registry/realm.ts
@@ -5,109 +5,106 @@ import { RequestService, ResponseService, RealmService } from "@services";
 
 // Models
 import { RealmErrors } from "@models";
+import { Operator } from "karikarihelper";
+import { InHouseError } from "@types";
 
 const router = Router();
 
-router.get("/", (req, res) => {
-    RealmService.query({
-        id: RequestService.queryParamToString(req.query.id),
-        name: RequestService.queryParamToString(req.query.name),
-    })
-        .then((response) => {
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
-        });
-});
-
-router.post("/", (req, res) => {
-    const name = RequestService.queryParamToString(req.body.name);
-
-    if (!name) {
-        res.status(400).json(
-            ResponseService.generateFailedResponse(RealmErrors.INVALID)
-        );
-
-        return;
-    }
-
-    RealmService.save({
-        name: name,
-    })
-        .then((response) => {
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
-        });
-});
-
-router.patch("/:id", (req, res) => {
-    const id = req.params.id;
-    const name = RequestService.queryParamToString(req.body.name);
-
-    if (!id) {
-        res.status(400).json(
-            ResponseService.generateFailedResponse(RealmErrors.INVALID)
-        );
-
-        return;
-    }
-
-    RealmService.update(id, { name: name })
-        .then((response) => {
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
-        });
-});
-
-router.delete("/:id", (req, res) => {
-    const id = req.params.id;
-
-    if (!id) {
-        res.status(400).json(
-            ResponseService.generateFailedResponse(RealmErrors.INVALID)
-        );
-
-        return;
-    }
-
-    RealmService.delete(id)
-        .then((response) => {
-            if (!response) {
-                res.status(404).json(
-                    ResponseService.generateFailedResponse(
-                        RealmErrors.NOT_FOUND
-                    )
-                );
-
-                return;
+router.get("/", async (req, res) => {
+    try {
+        const foundRealm = await RealmService.query(
+            res.locals.operator as Operator,
+            {
+                id: RequestService.queryParamToString(req.query.id),
+                name: RequestService.queryParamToString(req.query.name),
             }
+        );
 
-            res.status(200).json(
-                ResponseService.generateSucessfulResponse(response)
-            );
-        })
-        .catch((error) => {
-            res.status(error.code ?? 500).json(
-                ResponseService.generateFailedResponse(error.message)
-            );
-        });
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(foundRealm)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
+});
+
+router.post("/", async (req, res) => {
+    try {
+        const name = RequestService.queryParamToString(req.body.name);
+
+        if (!name) {
+            throw new InHouseError(RealmErrors.INVALID, 400);
+        }
+
+        const response = await RealmService.save(
+            res.locals.operator as Operator,
+            {
+                name: name,
+            }
+        );
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
+});
+
+router.patch("/:id", async (req, res) => {
+    try {
+        const id = req.params.id;
+        const name = RequestService.queryParamToString(req.body.name);
+
+        if (!id) {
+            throw new InHouseError(RealmErrors.INVALID, 400);
+        }
+
+        const response = await RealmService.update(
+            res.locals.operator as Operator,
+            id,
+            { name: name }
+        );
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
+});
+
+router.delete("/:id", async (req, res) => {
+    try {
+        const id = req.params.id;
+
+        if (!id) {
+            throw new InHouseError(RealmErrors.INVALID, 400);
+        }
+
+        const response = await RealmService.delete(
+            res.locals.operator as Operator,
+            id
+        );
+
+        if (!response) {
+            throw new InHouseError(RealmErrors.NOT_FOUND, 404);
+        }
+
+        res.status(200).json(
+            ResponseService.generateSucessfulResponse(response)
+        );
+    } catch (error) {
+        res.status(error.code ?? 500).json(
+            ResponseService.generateFailedResponse(error.message)
+        );
+    }
 });
 
 export default router;

--- a/services/web/karikariyaki/src/services/models/menu.ts
+++ b/services/web/karikariyaki/src/services/models/menu.ts
@@ -7,8 +7,9 @@ import {
     OperatorRole,
 } from "karikarihelper";
 
-// Models
-import { MenuModel } from "@models";
+// Types
+import { MenuModel, OperatorErrors } from "@models";
+import { InHouseError } from "@types";
 
 // Services
 import { DatabaseService, StringService } from "@services";
@@ -39,6 +40,10 @@ export class MenuService {
     ] as PopulateOptions[];
 
     public static async query(operator: Operator, values: MenuQueryableParams) {
+        if (MenuService._canPerformModifications(operator)) {
+            throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
+        }
+
         await DatabaseService.getConnection();
 
         const query = [];
@@ -108,7 +113,11 @@ export class MenuService {
             .populate(MenuService._getPopulateOptions(operator));
     }
 
-    public static async save(values: MenuCreatableParams) {
+    public static async save(operator: Operator, values: MenuCreatableParams) {
+        if (MenuService._canPerformModifications(operator)) {
+            throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
+        }
+
         await DatabaseService.getConnection();
 
         const newEntry = new MenuModel();
@@ -140,7 +149,15 @@ export class MenuService {
             .populate(MenuService._populateOptions);
     }
 
-    public static async update(id: string, values: MenuEditableParams) {
+    public static async update(
+        operator: Operator,
+        id: string,
+        values: MenuEditableParams
+    ) {
+        if (MenuService._canPerformModifications(operator)) {
+            throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
+        }
+
         await DatabaseService.getConnection();
 
         values.title = values.title?.trim();
@@ -171,7 +188,11 @@ export class MenuService {
             .populate(MenuService._populateOptions);
     }
 
-    public static async delete(id: string) {
+    public static async delete(operator: Operator, id: string) {
+        if (MenuService._canPerformModifications(operator)) {
+            throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
+        }
+
         await DatabaseService.getConnection();
 
         const menuId = StringService.toObjectId(id);
@@ -221,5 +242,9 @@ export class MenuService {
                 },
             },
         ] as PopulateOptions[];
+    }
+
+    private static _canPerformModifications(operator: Operator) {
+        return operator.role !== OperatorRole.ADMIN;
     }
 }

--- a/services/web/karikariyaki/src/services/models/menu.ts
+++ b/services/web/karikariyaki/src/services/models/menu.ts
@@ -75,7 +75,7 @@ export class MenuService {
             },
         });
 
-        return await MenuModel.find(
+        return MenuModel.find(
             query.length === 0
                 ? null
                 : {
@@ -105,7 +105,7 @@ export class MenuService {
             },
         });
 
-        return await MenuModel.find({
+        return MenuModel.find({
             $and: query,
         })
             .select(MenuService.visibleParameters)

--- a/services/web/karikariyaki/src/services/models/operator.ts
+++ b/services/web/karikariyaki/src/services/models/operator.ts
@@ -81,9 +81,7 @@ export class OperatorService {
             query.push(realmQuery);
         }
 
-        return await OperatorModel.find(
-            query.length === 0 ? null : { $and: query }
-        )
+        return OperatorModel.find(query.length === 0 ? null : { $and: query })
             .select(OperatorService.visibleParameters)
             .populate(OperatorService._populateOptions);
     }
@@ -91,7 +89,7 @@ export class OperatorService {
     public static async queryById(id: string) {
         await DatabaseService.getConnection();
 
-        return await OperatorModel.findById(id)
+        return OperatorModel.findById(id)
             .select(OperatorService.visibleParameters)
             .populate(OperatorService._populateOptions);
     }
@@ -99,7 +97,7 @@ export class OperatorService {
     public static async queryByUserName(userName: string) {
         await DatabaseService.getConnection();
 
-        return await OperatorModel.findOne({ userName: userName })
+        return OperatorModel.findOne({ userName: userName })
             .select(OperatorService.visibleParameters)
             .populate(OperatorService._populateOptions);
     }

--- a/services/web/karikariyaki/src/services/models/operator.ts
+++ b/services/web/karikariyaki/src/services/models/operator.ts
@@ -7,12 +7,12 @@ import {
     OperatorRole,
 } from "karikarihelper";
 
-// Models
+// Types
 import { OperatorErrors, OperatorModel } from "@models";
+import { InHouseError } from "@types";
 
 // Services
 import { DatabaseService, StringService } from "@services";
-import { InHouseError } from "@types";
 
 export class OperatorService {
     public static visibleParameters = ["displayName", "role", "realm", "photo"];

--- a/services/web/karikariyaki/src/services/models/operator.ts
+++ b/services/web/karikariyaki/src/services/models/operator.ts
@@ -157,7 +157,10 @@ export class OperatorService {
         if (operator.role !== OperatorRole.ADMIN) {
             const foundOperator = await OperatorService.queryId(id);
 
-            if (operator.realm._id !== foundOperator.realm._id.toString()) {
+            if (
+                operator.realm._id.toString() !==
+                foundOperator.realm._id.toString()
+            ) {
                 throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
             }
         }
@@ -187,7 +190,10 @@ export class OperatorService {
         if (operator.role !== OperatorRole.ADMIN) {
             const foundOperator = await OperatorService.queryId(id);
 
-            if (operator.realm._id !== foundOperator.realm._id.toString()) {
+            if (
+                operator.realm._id.toString() !==
+                foundOperator.realm._id.toString()
+            ) {
                 throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
             }
         }

--- a/services/web/karikariyaki/src/services/models/operator.ts
+++ b/services/web/karikariyaki/src/services/models/operator.ts
@@ -155,7 +155,7 @@ export class OperatorService {
         await DatabaseService.getConnection();
 
         if (operator.role !== OperatorRole.ADMIN) {
-            const foundOperator = await OperatorModel.findById(id);
+            const foundOperator = await OperatorService.queryId(id);
 
             if (operator.realm._id !== foundOperator.realm._id.toString()) {
                 throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
@@ -185,7 +185,7 @@ export class OperatorService {
         await DatabaseService.getConnection();
 
         if (operator.role !== OperatorRole.ADMIN) {
-            const foundOperator = await OperatorModel.findById(id);
+            const foundOperator = await OperatorService.queryId(id);
 
             if (operator.realm._id !== foundOperator.realm._id.toString()) {
                 throw new InHouseError(OperatorErrors.FORBIDDEN, 403);

--- a/services/web/karikariyaki/src/services/models/order.ts
+++ b/services/web/karikariyaki/src/services/models/order.ts
@@ -9,8 +9,6 @@ import {
 
 // Types
 import { InHouseError } from "@types";
-
-// Models
 import { EventModel, OperatorErrors, OrderErrors, OrderModel } from "@models";
 
 // Services

--- a/services/web/karikariyaki/src/services/models/product.ts
+++ b/services/web/karikariyaki/src/services/models/product.ts
@@ -7,12 +7,12 @@ import {
     ProductQueryableParams,
 } from "karikarihelper";
 
-// Models
+// Types
 import { OperatorErrors, ProductModel } from "@models";
+import { InHouseError } from "@types";
 
 // Services
 import { DatabaseService, StringService } from "@services";
-import { InHouseError } from "@types";
 
 export class ProductService {
     public static visibleParameters = ["name", "realm"];

--- a/services/web/karikariyaki/src/services/models/product.ts
+++ b/services/web/karikariyaki/src/services/models/product.ts
@@ -67,6 +67,14 @@ export class ProductService {
             .populate(ProductService._populateOptions);
     }
 
+    public static async queryById(id: string) {
+        await DatabaseService.getConnection();
+
+        return ProductModel.findById(StringService.toObjectId(id))
+            .select(ProductService.visibleParameters)
+            .populate(ProductService._populateOptions);
+    }
+
     public static async save(
         operator: Operator,
         values: ProductCreatableParams
@@ -99,7 +107,10 @@ export class ProductService {
         if (operator.role !== OperatorRole.ADMIN) {
             const foundOperator = await ProductModel.findById(id);
 
-            if (operator.realm._id !== foundOperator.realm._id.toString()) {
+            if (
+                operator.realm._id.toString() !==
+                foundOperator.realm._id.toString()
+            ) {
                 throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
             }
         }
@@ -123,29 +134,17 @@ export class ProductService {
         await DatabaseService.getConnection();
 
         if (operator.role !== OperatorRole.ADMIN) {
-            const foundOperator = await ProductModel.findById(id);
+            const foundProduct = await ProductService.queryById(id);
 
-            if (operator.realm._id !== foundOperator.realm._id.toString()) {
+            if (
+                operator.realm._id.toString() !==
+                foundProduct.realm._id.toString()
+            ) {
                 throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
             }
         }
 
         const productId = StringService.toObjectId(id);
-
-        await ProductModel.deleteMany({
-            parent: productId,
-        });
-
-        await ProductModel.updateMany(
-            {
-                variants: productId,
-            },
-            {
-                $pull: {
-                    variants: productId,
-                },
-            }
-        );
 
         return ProductModel.findByIdAndDelete(productId)
             .select(ProductService.visibleParameters)

--- a/services/web/karikariyaki/src/services/models/realm.ts
+++ b/services/web/karikariyaki/src/services/models/realm.ts
@@ -1,11 +1,14 @@
 import {
+    Operator,
+    OperatorRole,
     RealmCreatableParams,
     RealmEditableParams,
     RealmQueryableParams,
 } from "karikarihelper";
 
-// Models
-import { RealmModel } from "@models";
+// Types
+import { InHouseError } from "@types";
+import { OperatorErrors, RealmModel } from "@models";
 
 // Services
 import { DatabaseService, StringService } from "@services";
@@ -13,7 +16,14 @@ import { DatabaseService, StringService } from "@services";
 export class RealmService {
     public static visibleParameters = ["name"];
 
-    public static async query(values: RealmQueryableParams) {
+    public static async query(
+        operator: Operator,
+        values: RealmQueryableParams
+    ) {
+        if (operator.role !== OperatorRole.ADMIN) {
+            throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
+        }
+
         await DatabaseService.getConnection();
 
         const query = [];
@@ -35,7 +45,17 @@ export class RealmService {
         ).select(RealmService.visibleParameters);
     }
 
-    public static async save(values: RealmCreatableParams) {
+    public static async queryId(id: string) {
+        return RealmModel.findById(StringService.toObjectId(id)).select(
+            RealmService.visibleParameters
+        );
+    }
+
+    public static async save(operator: Operator, values: RealmCreatableParams) {
+        if (operator.role !== OperatorRole.ADMIN) {
+            throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
+        }
+
         await DatabaseService.getConnection();
 
         const newEntry = new RealmModel();
@@ -49,7 +69,15 @@ export class RealmService {
         );
     }
 
-    public static async update(id: string, values: RealmEditableParams) {
+    public static async update(
+        operator: Operator,
+        id: string,
+        values: RealmEditableParams
+    ) {
+        if (operator.role !== OperatorRole.ADMIN) {
+            throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
+        }
+
         await DatabaseService.getConnection();
 
         values.name = values.name?.trim();
@@ -65,7 +93,11 @@ export class RealmService {
         ).select(RealmService.visibleParameters);
     }
 
-    public static async delete(id: string) {
+    public static async delete(operator: Operator, id: string) {
+        if (operator.role !== OperatorRole.ADMIN) {
+            throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
+        }
+
         await DatabaseService.getConnection();
 
         const realmObjectId = StringService.toObjectId(id);

--- a/services/web/karikariyaki/src/services/models/realm.ts
+++ b/services/web/karikariyaki/src/services/models/realm.ts
@@ -20,7 +20,7 @@ export class RealmService {
         operator: Operator,
         values: RealmQueryableParams
     ) {
-        if (operator.role !== OperatorRole.ADMIN) {
+        if (RealmService._canPerformModifications(operator)) {
             throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
         }
 
@@ -52,7 +52,7 @@ export class RealmService {
     }
 
     public static async save(operator: Operator, values: RealmCreatableParams) {
-        if (operator.role !== OperatorRole.ADMIN) {
+        if (RealmService._canPerformModifications(operator)) {
             throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
         }
 
@@ -74,7 +74,7 @@ export class RealmService {
         id: string,
         values: RealmEditableParams
     ) {
-        if (operator.role !== OperatorRole.ADMIN) {
+        if (RealmService._canPerformModifications(operator)) {
             throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
         }
 
@@ -94,7 +94,7 @@ export class RealmService {
     }
 
     public static async delete(operator: Operator, id: string) {
-        if (operator.role !== OperatorRole.ADMIN) {
+        if (RealmService._canPerformModifications(operator)) {
             throw new InHouseError(OperatorErrors.FORBIDDEN, 403);
         }
 
@@ -105,5 +105,9 @@ export class RealmService {
         return RealmModel.findByIdAndDelete(realmObjectId).select(
             RealmService.visibleParameters
         );
+    }
+
+    private static _canPerformModifications(operator: Operator) {
+        return operator.role !== OperatorRole.ADMIN;
     }
 }

--- a/services/web/karikariyaki/src/sockets/reji.ts
+++ b/services/web/karikariyaki/src/sockets/reji.ts
@@ -5,7 +5,6 @@ import { io } from "../setup";
 
 // Routes
 import {
-    createEvent,
     createOrder,
     deleteOrder,
     editOrder,
@@ -63,7 +62,6 @@ export class RejiSocket {
              */
             socket.data.operator = loggedOperator;
 
-            createEvent(socket);
             joinEvent(socket);
             leaveEvent(socket);
 

--- a/services/web/karikariyaki/src/sockets/routes/index.ts
+++ b/services/web/karikariyaki/src/sockets/routes/index.ts
@@ -1,3 +1,3 @@
-export { createEvent, joinEvent, leaveEvent } from "./event";
+export { joinEvent, leaveEvent } from "./event";
 export { joinEvents, leaveEvents } from "./events";
 export { createOrder, deleteOrder, editOrder, joinOrder } from "./orders";


### PR DESCRIPTION
## Info

As of right now there's a **lot** of holes when it comes to security when modifying and creating entries that are **operator** based. 

_A.K.A Everything..._

This **PR** it's focused on fixing that. 

_PS: This **PR** also ships the total conversion of endpoints to `try catch`_ o(≧▽≦)o

## Problems  

1. Remove await `db` responses on return.
2. Remove the ability to non-admin operator to create events;  _This rule aims to comply with the new `back-end` rules, thus requiring changes on both at `endpoints` and `sockets`_
3. Implement roles to the models services.

## Fix

- [x] 1. Removed useless await snippets at e37d1fe4d94ef39e4bd8c1fb003529837f71b5e8;
- [x] 2. Removed the ability for non-admins to create events at 3f43b65b2263b9758150021e7fdfacd1463df0bb
- [x] 3. Implemented roles to the models services:
- [x] 3.1. Improved `operator` creation & edition security at f55bc734edfd469267e08c8c8a2c9ca93de3b4b5;
- [x] 3.2. Improved `product` creation & edition security at f61d4969b10b99627fe7f835ce8587baaf0c1b79;
- [x] 3.3. Improved `event order` creation & edition security at e5b2e27a4a13882ce2dc3d1be9982b52769bb202;
- [x] 3.4. Improved `menu` creation & edition security at 508785da55a746489eaf44914188bb1a7bc6fca3;
